### PR TITLE
DLT init reusing lakeflow-pipelines template

### DIFF
--- a/cmd/dlt/init.go
+++ b/cmd/dlt/init.go
@@ -1,0 +1,46 @@
+package dlt
+
+import (
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/template"
+	"github.com/spf13/cobra"
+)
+
+func initCommand() *cobra.Command {
+	var outputDir string
+	var configFile string
+	cmd := &cobra.Command{
+		Use:     "init",
+		Short:   "Initialize a new DLT project",
+		PreRunE: root.MustWorkspaceClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			r := template.Resolver{
+				TemplatePathOrUrl: "lakeflow-pipelines",
+				ConfigFile:        configFile,
+				OutputDir:         outputDir,
+			}
+
+			tmpl, err := r.Resolve(ctx)
+			if err != nil {
+				return err
+			}
+			defer tmpl.Reader.Cleanup(ctx)
+
+			err = tmpl.Writer.PromptForInput(ctx, tmpl.Reader)
+			if err != nil {
+				return err
+			}
+			tmpl.Writer.SetConfig("is_dlt", true)
+			err = tmpl.Writer.Finalize(ctx)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&outputDir, "output-dir", "", "Directory to write the initialized template to")
+	cmd.Flags().StringVar(&configFile, "config-file", "", "JSON file containing key value pairs of input parameters required for template initialization")
+	return cmd
+}

--- a/libs/template/templates/lakeflow-pipelines/databricks_template_schema.json
+++ b/libs/template/templates/lakeflow-pipelines/databricks_template_schema.json
@@ -9,6 +9,12 @@
             "pattern": "^[a-z0-9_]+$",
             "pattern_match_failure_message": "Name must consist of lower case letters, numbers, and underscores."
         },
+        "is_dlt": {
+            "skip_prompt_if": {},
+            "type": "boolean",
+            "description": "DLT pipelines using this template",
+            "default": false
+        },
         "default_catalog": {
             "type": "string",
             "default": "{{default_catalog}}",

--- a/libs/template/templates/lakeflow-pipelines/template/__preamble.tmpl
+++ b/libs/template/templates/lakeflow-pipelines/template/__preamble.tmpl
@@ -5,6 +5,7 @@ This file only contains template directives; it is skipped for the actual output
 {{skip "__preamble"}}
 
 {{$isSQL := eq .language "sql"}}
+{{$isDLT := eq .is_dlt true}}
 
 {{if $isSQL}}
   {{skip "{{.project_name}}/resources/{{.project_name}}_pipeline/utilities/utils.py"}}
@@ -13,4 +14,8 @@ This file only contains template directives; it is skipped for the actual output
 {{else}}
   {{skip "{{.project_name}}/resources/{{.project_name}}_pipeline/transformations/sample_zones_{{.project_name}}.sql"}}
   {{skip "{{.project_name}}/resources/{{.project_name}}_pipeline/transformations/sample_trips_{{.project_name}}.sql"}}
+{{end}}
+
+{{if $isDLT}}
+  {{skip "{{.project_name}}/resources/{{.project_name}}_pipeline/{{.project_name}}.job.yml"}}
 {{end}}

--- a/libs/template/templates/lakeflow-pipelines/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/lakeflow-pipelines/template/{{.project_name}}/databricks.yml.tmpl
@@ -1,12 +1,12 @@
 # This is a Databricks asset bundle definition for {{.project_name}}.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
-bundle:
+{{$isDLT := eq .is_dlt true}}{{if $isDLT}}project{{else}}bundle{{end}}:
   name: {{.project_name}}
-  uuid: {{bundle_uuid}}
+  {{if not $isDLT}}uuid: {{bundle_uuid}}{{end}}
 
 include:
-  - resources/*.yml
-  - resources/*/*.yml
+  {{if $isDLT}}- ./*.yml{{else}}- resources/*.yml
+  - resources/*/*.yml{{end}}
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:
@@ -25,6 +25,7 @@ targets:
     # See also https://docs.databricks.com/dev-tools/bundles/deployment-modes.html.
     mode: development
     default: true
+    {{if $isDLT}}deploy_on_run: true{{end}}
     workspace:
       host: {{workspace_host}}
     variables:
@@ -36,11 +37,11 @@ targets:
     mode: production
     workspace:
       host: {{workspace_host}}
-      # We explicitly deploy to /Workspace/Users/{{user_name}} to make sure we only have a single copy.
-      root_path: /Workspace/Users/{{user_name}}/.bundle/${bundle.name}/${bundle.target}
-    permissions:
+      {{if not $isDLT}}# We explicitly deploy to /Workspace/Users/{{user_name}} to make sure we only have a single copy.
+      root_path: /Workspace/Users/{{user_name}}/.bundle/${bundle.name}/${bundle.target}}{{end}}
+    {{if $isDLT}}owner: user@company.com{{else}}permissions:
       - {{if is_service_principal}}service_principal{{else}}user{{end}}_name: {{user_name}}
-        level: CAN_MANAGE
+        level: CAN_MANAGE{{end}}
     variables:
       catalog: {{.default_catalog}}
       schema: {{template `prod_schema` .}}


### PR DESCRIPTION
## Changes
New `dlt init` command that generates a pipeline specific template.
Adding new field to schema that allows for reusing lakeflow-pipelines template for DLT 

## Why
Allow for `dlt init` command to reuse template

## Tests
Acceptance tests pending but locally generates 2 sets of files if using `databricks bundle init` or `dlt init`

